### PR TITLE
feat: Add YouTube playlist feature

### DIFF
--- a/src/components/Pomodoro.css
+++ b/src/components/Pomodoro.css
@@ -173,6 +173,196 @@
   outline: none !important;
 }
 
+.youtube-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 600px;
+  width: 100%;
+}
+
+.youtube-input-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.youtube-url-input {
+  color: var(--text-color);
+  background: transparent;
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: clamp(0.9rem, 2vw, 1rem);
+  transition: all 0.8s ease;
+  box-shadow: none !important;
+  outline: none !important;
+  min-width: 250px;
+  max-width: 400px;
+  flex: 1;
+  font-family: inherit;
+}
+
+.youtube-url-input:focus {
+  box-shadow: none !important;
+  outline: none !important;
+  border-color: var(--text-color);
+}
+
+.youtube-url-input::placeholder {
+  color: var(--secondary-text-color);
+  opacity: 0.6;
+}
+
+.youtube-button {
+  background: transparent !important;
+  color: var(--text-color) !important;
+  border: 2px solid var(--border-color) !important;
+  border-radius: 8px !important;
+  padding: 8px 16px !important;
+  font-size: 1rem !important;
+  cursor: pointer !important;
+  transition: all 0.3s ease;
+  box-shadow: none !important;
+  outline: none !important;
+  min-width: 40px;
+}
+
+.youtube-button:hover {
+  box-shadow: none !important;
+  background: var(--text-color) !important;
+  color: var(--bg-color) !important;
+  opacity: 0.8;
+}
+
+.youtube-button:focus {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.youtube-play-button {
+  background: var(--text-color) !important;
+  color: var(--bg-color) !important;
+  border: 2px solid var(--text-color) !important;
+  border-radius: 8px !important;
+  padding: 8px 16px !important;
+  font-size: 1rem !important;
+  cursor: pointer !important;
+  transition: all 0.3s ease;
+  box-shadow: none !important;
+  outline: none !important;
+  min-width: 40px;
+  font-weight: 600;
+}
+
+.youtube-play-button:hover {
+  box-shadow: none !important;
+  background: var(--text-color) !important;
+  color: var(--bg-color) !important;
+  opacity: 0.9;
+  transform: scale(1.05);
+}
+
+.youtube-play-button:focus {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.youtube-play-button:disabled {
+  opacity: 0.5 !important;
+  cursor: not-allowed !important;
+  transform: none !important;
+}
+
+.youtube-clear-button {
+  opacity: 0.7;
+}
+
+.youtube-status {
+  color: var(--secondary-text-color);
+  font-size: clamp(0.8rem, 1.8vw, 0.9rem);
+  transition: color 0.8s ease;
+  text-align: center;
+}
+
+.youtube-queue {
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.youtube-queue::-webkit-scrollbar {
+  width: 8px;
+}
+
+.youtube-queue::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.youtube-queue::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 4px;
+}
+
+.youtube-queue::-webkit-scrollbar-thumb:hover {
+  background: var(--text-color);
+}
+
+.youtube-queue-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  transition: all 0.3s ease;
+  cursor: pointer;
+  color: var(--text-color);
+  background: transparent;
+}
+
+.youtube-queue-item.active {
+  background: var(--secondary-text-color) !important;
+  color: var(--bg-color) !important;
+  font-weight: 500;
+}
+
+.youtube-queue-item:not(.active):hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(4px);
+}
+
+.youtube-queue-item-text {
+  flex: 1;
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.youtube-queue-button {
+  padding: 4px !important;
+  min-width: unset !important;
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+}
+
+.youtube-queue-button:hover {
+  opacity: 1;
+}
+
 /* Mobile optimizations */
 @media (max-width: 768px) {
   .timer-display {

--- a/src/components/Pomodoro.tsx
+++ b/src/components/Pomodoro.tsx
@@ -1,11 +1,13 @@
 import { Box, Button, Page } from 'grommet';
-import { SettingsOption } from 'grommet-icons';
+import { SettingsOption, Play, Pause, Add, Trash, Close } from 'grommet-icons';
 import React, { useEffect, useState } from 'react';
 import { useTimer } from 'react-timer-hook';
 import { usePomodoroContext } from '../contexts/PomodoroContext';
 import { useCalculatedColors } from '../hooks/useCalculatedColors';
 import { useSounds } from '../hooks/useSounds';
-import { getItemFromLocalStorage } from '../utils/localStorage';
+import { useYouTubePlayer } from '../hooks/useYouTubePlayer';
+import type { YouTubeQueueItem } from '../hooks/useYouTubePlayer';
+import { getItemFromLocalStorage, setItemToLocalStorage } from '../utils/localStorage';
 import {
   DEFAULT_LONG_BREAK_TIME,
   DEFAULT_POMODORO_TIME,
@@ -25,6 +27,12 @@ const modeLabels: Record<Mode, string> = {
   pomodoro: 'Pomodoro',
   shortBreak: 'Descanso corto',
   longBreak: 'Descanso largo',
+};
+
+const extractVideoId = (url: string): string | null => {
+  const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+  const match = url.match(regExp);
+  return (match && match[2].length === 11) ? match[2] : null;
 };
 
 const Pomodoro: React.FC = () => {
@@ -50,6 +58,7 @@ const Pomodoro: React.FC = () => {
   const completedPomodoros = timerState.completedPomodoros;
 
   const [inputValue, setInputValue] = useState<string>('');
+  const [youtubeUrl, setYoutubeUrl] = useState<string>('');
 
   useEffect(() => {
     setInputValue(completedPomodoros.toString());
@@ -100,6 +109,30 @@ const Pomodoro: React.FC = () => {
     }
   };
 
+  const handleYoutubeUrlSubmit = () => {
+    const videoId = extractVideoId(youtubeUrl);
+    console.log('URL ingresada:', youtubeUrl);
+    console.log('Video ID extraído:', videoId);
+    if (videoId) {
+      const newItem: YouTubeQueueItem = {
+        id: `${videoId}-${Date.now()}`,
+        videoId,
+        title: youtubeUrl,
+        url: youtubeUrl,
+      };
+      console.log('Agregando a cola:', newItem);
+      youtube.addToQueue(newItem);
+      setYoutubeUrl('');
+    } else {
+      console.log('URL inválida, no se pudo extraer videoId');
+    }
+  };
+
+  const handleClearQueue = () => {
+    youtube.clearQueue();
+    setItemToLocalStorage('youtubeQueue', '[]');
+  };
+
   const { minutes, seconds, pause, isRunning, resume, restart } = useTimer({
     expiryTimestamp: (() => {
       const { minutes, seconds } = getCurrentModeTime();
@@ -122,6 +155,37 @@ const Pomodoro: React.FC = () => {
       }
     },
   });
+
+  const youtube = useYouTubePlayer(isRunning);
+
+  useEffect(() => {
+    const savedQueue = getItemFromLocalStorage('youtubeQueue', '[]');
+    try {
+      const parsedQueue = JSON.parse(savedQueue);
+      console.log('Cola guardada en localStorage:', parsedQueue);
+      if (Array.isArray(parsedQueue) && parsedQueue.length > 0) {
+        parsedQueue.forEach((item: any) => {
+          // Validar que el item tenga la estructura correcta
+          if (item && item.videoId && item.url) {
+            youtube.addToQueue(item);
+          } else {
+            console.warn('Item inválido en cola guardada:', item);
+          }
+        });
+      }
+    } catch (e) {
+      console.error('Error loading YouTube queue:', e);
+      // Limpiar localStorage si hay error
+      setItemToLocalStorage('youtubeQueue', '[]');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (youtube.queue.length > 0) {
+      setItemToLocalStorage('youtubeQueue', JSON.stringify(youtube.queue));
+    }
+  }, [youtube.queue]);
 
   useEffect(() => {
     const { minutes: mins, seconds: secs } = getCurrentModeTime();
@@ -274,6 +338,83 @@ const Pomodoro: React.FC = () => {
             />
           </Box>
         </Box>
+
+        {/* YouTube Player Controls */}
+        <Box align="center" gap="medium" className="youtube-container">
+          {/* Add to Queue */}
+          <Box direction="row" gap="small" align="center" className="youtube-input-container">
+            <input
+              type="text"
+              value={youtubeUrl}
+              onChange={(e) => setYoutubeUrl(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && handleYoutubeUrlSubmit()}
+              placeholder="Pega URL de YouTube aquí"
+              className="youtube-url-input"
+            />
+            <Button
+              icon={<Add size="small" color={colors.text} />}
+              onClick={handleYoutubeUrlSubmit}
+              className="youtube-button"
+            />
+          </Box>
+
+          {/* Player Controls */}
+          {youtube.queue.length > 0 && (
+            <Box gap="small" align="center">
+              <Box direction="row" gap="small" align="center" justify="center">
+                <Button
+                  icon={youtube.isPlaying ? <Pause size="small" color={colors.background} /> : <Play size="small" color={colors.background} />}
+                  onClick={youtube.togglePlayPause}
+                  // disabled={!youtube.isPlayerReady}
+                  className="youtube-play-button"
+                />
+                <Button
+                  icon={<Trash size="small" color={colors.text} />}
+                  onClick={handleClearQueue}
+                  className="youtube-button youtube-clear-button"
+                />
+              </Box>
+
+              {/* Current Video Info */}
+              {youtube.currentVideo && (
+                <span className="youtube-status">
+                  🎵 {youtube.currentIndex + 1}/{youtube.queue.length}: {youtube.currentVideo.title.slice(0, 50)}...
+                </span>
+              )}
+
+              {/* Queue List */}
+              <Box gap="xsmall" className="youtube-queue">
+                {youtube.queue.map((item, index) => (
+                  <Box
+                    key={item.id}
+                    direction="row"
+                    gap="small"
+                    align="center"
+                    justify="between"
+                    className={`youtube-queue-item ${index === youtube.currentIndex ? 'active' : ''}`}
+                    onClick={() => youtube.playAtIndex(index)}
+                  >
+                    <span className="youtube-queue-item-text">
+                      {index + 1}. {item.title.slice(0, 40)}...
+                    </span>
+                    <Button
+                      icon={<Close size="small" color={index === youtube.currentIndex ? colors.background : colors.text} />}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        youtube.removeFromQueue(item.id);
+                      }}
+                      plain
+                      className="youtube-queue-button"
+                    />
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          )}
+        </Box>
+
+        {/* Hidden YouTube Player */}
+        <div id="youtube-player" style={{ display: 'none' }}></div>
 
         <Button
           icon={<SettingsOption size="large" color={colors.text} />}

--- a/src/hooks/useYouTubePlayer.ts
+++ b/src/hooks/useYouTubePlayer.ts
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface YouTubePlayer {
+  playVideo: () => void;
+  pauseVideo: () => void;
+  stopVideo: () => void;
+  loadVideoById: (videoId: string) => void;
+  cueVideoById: (videoId: string) => void;
+  getPlayerState: () => number;
+}
+
+declare global {
+  interface Window {
+    YT: {
+      Player: new (elementId: string, config: any) => YouTubePlayer;
+      PlayerState: {
+        PLAYING: number;
+        PAUSED: number;
+        ENDED: number;
+        UNSTARTED: number;
+        CUED: number;
+      };
+    };
+    onYouTubeIframeAPIReady?: () => void;
+  }
+}
+
+export interface YouTubeQueueItem {
+  id: string;
+  videoId: string;
+  title: string;
+  url: string;
+}
+
+export const useYouTubePlayer = (shouldPlay: boolean) => {
+  const playerRef = useRef<YouTubePlayer | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [isPlayerReady, setIsPlayerReady] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [queue, setQueue] = useState<YouTubeQueueItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const hasManuallyInteracted = useRef(false); // Track if user has manually interacted
+
+  // Load YouTube IFrame API
+  useEffect(() => {
+    if (!document.getElementById('youtube-iframe-api')) {
+      const tag = document.createElement('script');
+      tag.id = 'youtube-iframe-api';
+      tag.src = 'https://www.youtube.com/iframe_api';
+      const firstScriptTag = document.getElementsByTagName('script')[0];
+      firstScriptTag.parentNode?.insertBefore(tag, firstScriptTag);
+    }
+
+    window.onYouTubeIframeAPIReady = () => {
+      setIsReady(true);
+    };
+
+    if (window.YT && window.YT.Player) {
+      setIsReady(true);
+    }
+  }, []);
+
+  // Create player when API is ready and we have videos in queue
+  useEffect(() => {
+    if (isReady && queue.length > 0 && !playerRef.current) {
+      const firstVideo = queue[currentIndex];
+      playerRef.current = new window.YT.Player('youtube-player', {
+        height: '0',
+        width: '0',
+        videoId: firstVideo.videoId,
+        playerVars: {
+          autoplay: 0,
+          controls: 0,
+          disablekb: 1,
+          modestbranding: 1,
+        },
+        events: {
+          onReady: () => {
+            setIsPlayerReady(true);
+          },
+          onStateChange: (event: any) => {
+            setIsPlaying(event.data === window.YT.PlayerState.PLAYING);
+
+            // Auto-play next video when current ends
+            if (event.data === window.YT.PlayerState.ENDED) {
+              playNext();
+            }
+          },
+        },
+      });
+    }
+  }, [isReady, queue.length]);
+
+  // Handle play/pause based on timer state (only when timer state changes)
+  useEffect(() => {
+    console.log('Timer sync effect:', {
+      hasManuallyInteracted: hasManuallyInteracted.current,
+      isPlayerReady,
+      queueLength: queue.length,
+      shouldPlay,
+      isPlaying
+    });
+    // Only sync with timer if user has manually started playback
+    if (hasManuallyInteracted.current && isPlayerReady && playerRef.current && queue.length > 0) {
+      console.log('Syncing with timer...');
+      if (shouldPlay && !isPlaying) {
+        console.log('Playing video (timer)');
+        playerRef.current.playVideo();
+      } else if (!shouldPlay && isPlaying) {
+        console.log('Pausing video (timer)');
+        playerRef.current.pauseVideo();
+      }
+    }
+    // Note: queue.length and isPlaying are intentionally NOT in dependencies
+    // to avoid auto-play when adding items and conflicts with manual controls
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldPlay, isPlayerReady]);
+
+  // Load new video when current index changes
+  useEffect(() => {
+    if (isPlayerReady && playerRef.current && queue.length > 0) {
+      const currentVideo = queue[currentIndex];
+      if (currentVideo) {
+        // Use cueVideoById instead of loadVideoById to prevent auto-play
+        playerRef.current.cueVideoById(currentVideo.videoId);
+      }
+    }
+  }, [currentIndex, isPlayerReady]);
+
+  const togglePlayPause = () => {
+    console.log('togglePlayPause called');
+    if (playerRef.current && isPlayerReady) {
+      hasManuallyInteracted.current = true; // Mark that user has interacted
+      console.log('Setting hasManuallyInteracted to true');
+      if (isPlaying) {
+        console.log('Pausing video (manual)');
+        playerRef.current.pauseVideo();
+      } else {
+        console.log('Playing video (manual)');
+        playerRef.current.playVideo();
+      }
+    }
+  };
+
+  const addToQueue = (item: YouTubeQueueItem) => {
+    console.log('addToQueue llamado con:', item);
+    setQueue((prev) => {
+      // Check if item with same id already exists
+      const exists = prev.some((existingItem) => existingItem.id === item.id);
+      if (exists) {
+        console.log('Item ya existe en la cola, no se agrega:', item.id);
+        return prev;
+      }
+      const newQueue = [...prev, item];
+      console.log('Nueva cola:', newQueue);
+      return newQueue;
+    });
+  };
+
+  const removeFromQueue = (id: string) => {
+    setQueue((prev) => {
+      const newQueue = prev.filter((item) => item.id !== id);
+      // Adjust current index if needed
+      const removedIndex = prev.findIndex((item) => item.id === id);
+      if (removedIndex < currentIndex) {
+        setCurrentIndex((idx) => Math.max(0, idx - 1));
+      } else if (removedIndex === currentIndex && newQueue.length > 0) {
+        // If we're removing the current video, stay at same index or adjust if at end
+        if (currentIndex >= newQueue.length) {
+          setCurrentIndex(newQueue.length - 1);
+        }
+      } else if (newQueue.length === 0) {
+        setCurrentIndex(0);
+      }
+      return newQueue;
+    });
+  };
+
+  const clearQueue = () => {
+    setQueue([]);
+    setCurrentIndex(0);
+    if (playerRef.current && isPlayerReady) {
+      playerRef.current.stopVideo();
+      setIsPlaying(false);
+    }
+  };
+
+  const playNext = () => {
+    if (queue.length > 0 && currentIndex < queue.length - 1) {
+      setCurrentIndex((idx) => idx + 1);
+      const nextVideo = queue[currentIndex + 1];
+      if (playerRef.current && isPlayerReady) {
+        // Use loadVideoById for next video - we want it to continue playing
+        playerRef.current.loadVideoById(nextVideo.videoId);
+      }
+    }
+  };
+
+  const playAtIndex = (index: number) => {
+    if (queue.length > 0 && index >= 0 && index < queue.length) {
+      setCurrentIndex(index);
+      const video = queue[index];
+      if (playerRef.current && isPlayerReady) {
+        // Use cueVideoById to load without auto-playing
+        playerRef.current.cueVideoById(video.videoId);
+      }
+    }
+  };
+
+  return {
+    playerRef,
+    isPlaying,
+    isPlayerReady,
+    queue,
+    currentIndex,
+    currentVideo: queue[currentIndex] || null,
+    togglePlayPause,
+    addToQueue,
+    removeFromQueue,
+    clearQueue,
+    playAtIndex,
+  };
+};


### PR DESCRIPTION
## Description
This PR implements a YouTube playlist feature that allows users to play background music/sounds during their Pomodoro sessions.

## Changes
- ✨ Added YouTube player integration with custom hook `useYouTubePlayer`
- 🎵 YouTube video playback syncs with timer state (plays when running, pauses when paused)
- 🎨 UI controls for adding/removing YouTube URLs to playlist
- 📋 Playlist management (add, remove, navigate between videos)
- 🔄 Auto-play next video when current one ends
- 💾 Playlist persistence in localStorage

## Implementation Details
- Created `useYouTubePlayer.ts` hook for managing YouTube IFrame API
- Updated `Pomodoro.tsx` with playlist UI and state management
- Styled playlist controls in `Pomodoro.css`

## Related Issue
Closes #6

## Testing
- ✅ YouTube videos play/pause correctly with timer state
- ✅ Playlist navigation works as expected
- ✅ Invalid URLs are handled gracefully
- ✅ Playlist persists across page reloads