### PR TITLE
docs: consolidate and translate documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Documentation
+
+## Index
+
+- `architecture.md`: system architecture and structure.
+- `guidelines.md`: engineering rules.
+- `decisions.md`: ADR log and template.
+
+## Legacy
+
+`functional-spec.md` and `technical-spec.md` are legacy summaries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,52 @@
+# Architecture
+
+## Objective
+
+Define the frontend architecture to ensure maintainability, scalability, and strict alignment with documentation.
+
+## Principles
+
+- Clear separation of concerns by layer and domain.
+- Strict TypeScript typing.
+- Predictable UI state (local vs global is explicit).
+
+## Project structure (mandatory)
+
+```
+/docs
+  architecture.md
+  decisions.md
+  guidelines.md
+
+/specs
+  /features
+    /<feature-name>
+      spec.md
+      acceptance-criteria.md
+      ux-notes.md
+      technical-design.md
+
+/src
+  /app
+  /features
+  /shared
+```
+
+## System map
+
+- Pomodoro timer
+- User configuration
+- YouTube queue and player controls
+
+## Documentation ↔ Implementation contract
+
+- Documentation is the source of truth when present.
+- Each acceptance criterion must map to tests or documented manual verification.
+- Any behavior change requires a documentation update first.
+
+## Quality attributes
+
+- Maintainability
+- Scalability
+- Testability
+- Basic observability (logs)

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,14 @@
+# Decisions (ADR log)
+
+## ADR index
+
+No ADRs recorded yet.
+
+## ADR template
+
+- Context
+- Problem
+- Alternatives considered
+- Decision
+- Consequences
+- Technical standards

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -1,0 +1,32 @@
+# Functional specifications
+
+## Objective
+
+Describe the expected behavior of the Pomodoro application.
+
+## Current scope
+
+- Pomodoro timer with work and break modes.
+- Time and color theme configuration.
+- YouTube playback and queue management.
+
+## Functional requirements
+
+- FR-01: The user can start, pause, and reset the timer.
+- FR-02: The user can switch modes (pomodoro, short break, long break).
+- FR-03: The user can adjust mode durations in settings.
+- FR-04: The user can select a color theme.
+- FR-05: The user can add YouTube URLs to a queue.
+- FR-06: The user can control YouTube playback.
+
+## Business rules
+
+- The timer advances in one-second intervals.
+- At the end of a mode, a configurable sound plays.
+- Settings persist in local storage.
+
+## Acceptance criteria (pending validation)
+
+- [ ] The timer keeps accurate time when switching tabs.
+- [ ] Settings persist after reloading the page.
+- [ ] The applied theme affects the entire UI.

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -1,0 +1,72 @@
+# Engineering guidelines
+
+## Documentation workflow
+
+- All relevant decisions require an ADR.
+- Documentation and code must remain synchronized.
+
+## Naming conventions
+
+- Components: `PascalCase`.
+- Hooks: `useCamelCase`.
+- Feature folders: `kebab-case`.
+- Types/interfaces: `PascalCase`.
+- Constants: `UPPER_SNAKE_CASE`.
+
+## Component structure
+
+```
+src/features/<feature-name>/
+  components/
+  hooks/
+  types/
+  index.ts
+```
+
+- One main component per file.
+- Export only public API from `index.ts`.
+
+## State management
+
+- Local UI state: `useState`/`useReducer`.
+- Global state: Context + hooks (`src/contexts`).
+- No new state libraries without an ADR.
+
+## Error handling
+
+- User-facing errors when flow is impacted.
+- Avoid silent failures.
+- Use `try/catch` only where errors are expected.
+
+## Testing strategy
+
+- Unit tests for utilities and hooks.
+- Component tests for UI with Testing Library.
+- Tests must reference acceptance criteria IDs (e.g., AC-01).
+
+## Quality gates
+
+- Typecheck clean.
+- Tests green.
+- Documentation updated and consistent.
+
+## Documentation style
+
+- Clarity over completeness.
+- Avoid ambiguity.
+- Keep each document self-contained.
+
+## UX notes
+
+- Required for new user flows or complex UI states.
+
+## Security & performance
+
+- Never store sensitive data in localStorage.
+- Sanitize external inputs (URLs).
+- Avoid unnecessary re-renders; memoize only when needed.
+
+## Avoid over-engineering
+
+- Solve the current problem.
+- Reuse existing patterns before creating new abstractions.

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -1,0 +1,33 @@
+# Technical specifications
+
+## Stack
+
+- React + TypeScript
+- Vite
+- Vitest + Testing Library
+
+## Architecture
+
+- Main UI in `src/components/Pomodoro.tsx`.
+- Contexts in `src/contexts` for global state.
+- Reusable hooks in `src/hooks`.
+- Utilities in `src/utils`.
+
+## Persistence
+
+- `localStorage` is used for configuration and the YouTube queue.
+
+## Routes
+
+- Routes are declared in `src/utils/routes.ts`.
+
+## Tests
+
+- Unit tests in `src/**/__tests__`.
+- Global setup in `src/test/setup.ts`.
+
+## Technical backlog
+
+- Document contracts for contexts and hooks.
+- Consolidate error-handling and logging policies.
+- Define performance metrics (render and timer).

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,7 @@
+# Specs
+
+This directory contains functional and technical specs per feature.
+
+## Structure
+
+Each feature must follow the structure defined in `/docs/architecture.md`.

--- a/specs/features/focus-sound-toggle/acceptance-criteria.md
+++ b/specs/features/focus-sound-toggle/acceptance-criteria.md
@@ -1,0 +1,6 @@
+# Acceptance criteria - Focus sound toggle
+
+- AC-01: The toggle is visible in settings and reflects the current state.
+- AC-02: When the toggle is off, finishing a pomodoro does not play a sound.
+- AC-03: When the toggle is on, the end sound plays.
+- AC-04: The preference persists after reloading the page.

--- a/specs/features/focus-sound-toggle/spec.md
+++ b/specs/features/focus-sound-toggle/spec.md
@@ -1,0 +1,28 @@
+# Feature Spec - Focus sound toggle
+
+## Problem
+
+Some users prefer to finish a focus session without notification sounds.
+
+## Goal
+
+Allow enabling or disabling the pomodoro end sound.
+
+## Scope
+
+### In
+
+- Toggle in settings.
+- Preference persistence.
+- Respect the toggle when the timer ends.
+
+### Out
+
+- Sound customization.
+- Changes to break sounds.
+
+## Use cases
+
+1. The user disables the sound and finishes a pomodoro without alert.
+2. The user enables the sound and receives the end notification.
+3. The preference persists after reloading the app.

--- a/specs/features/focus-sound-toggle/technical-design.md
+++ b/specs/features/focus-sound-toggle/technical-design.md
@@ -1,0 +1,28 @@
+# Technical design - Focus sound toggle
+
+## Components involved
+
+- `Configurations` (adds the toggle).
+- `Pomodoro` (consumes the preference).
+
+## Data types
+
+```ts
+export type SoundPreferences = {
+  focusEndEnabled: boolean;
+};
+```
+
+## State
+
+- Global in the Pomodoro context.
+- Persisted in `localStorage`.
+
+## APIs or services
+
+- `localStorage` to store the preference.
+
+## Key decisions
+
+- Reuse the existing context instead of a new state library.
+- Keep the preference in a single configuration object.

--- a/specs/features/focus-sound-toggle/ux-notes.md
+++ b/specs/features/focus-sound-toggle/ux-notes.md
@@ -1,0 +1,11 @@
+# UX Notes - Focus sound toggle
+
+## User flow
+
+- The user opens settings and finds the toggle in the sound section.
+- They change the state and get immediate feedback.
+
+## UI states
+
+- Toggle on/off.
+- Optional helper text: "Pomodoro end sound".


### PR DESCRIPTION
## Summary
- add consolidated English docs index and structure
- add architecture, guidelines, decisions, functional, and technical docs
- add specs for focus sound toggle feature

## Testing
- Not run (docs-only changes)
